### PR TITLE
Adding throws to the implementation.

### DIFF
--- a/src/main/java/culturemedia/exception/VideoNotFoundException.java
+++ b/src/main/java/culturemedia/exception/VideoNotFoundException.java
@@ -4,7 +4,7 @@ import java.text.MessageFormat;
 
 public class VideoNotFoundException extends CulturotecaException{
     public VideoNotFoundException(){
-        super("Video not found");
+        super("Video not found.");
     }
     public VideoNotFoundException(String title){
         super(MessageFormat.format("Video not found by title {0}",title));


### PR DESCRIPTION
Cambié el nombre de la excepcion VideoNotFoundByTitle por VideoNotFound, y se lanzó la excepción para que a la hora de agregar un video se verifiqué que la duración sea válida. Y algunos otros cambios.