### PR TITLE
Adding mocks in service-test-cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,13 @@
             <version>2.23.1</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.14.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/culturemedia/controllers/CulturotecaController.java
+++ b/src/main/java/culturemedia/controllers/CulturotecaController.java
@@ -6,25 +6,24 @@ import culturemedia.exception.VideoNotFoundException;
 import culturemedia.model.Video;
 import culturemedia.service.CulturotecaService;
 
-public class CultureMediaController {
+public class CulturotecaController {
 
-	private final CulturotecaService cultureMediaService;
+	private final CulturotecaService culturotecaService;
 
-
-	public CultureMediaController(CulturotecaService cultureMediaService) {
-		this.cultureMediaService = cultureMediaService;
+	public CulturotecaController(CulturotecaService culturotecaService) {
+		this.culturotecaService = culturotecaService;
 	}
 
 	public List<Video> findAllVideos() throws VideoNotFoundException {
-
-		List<Video> videos = cultureMediaService.findAll();
+		List<Video> videos = culturotecaService.findAll();
 		if (videos.isEmpty()){
 			throw new VideoNotFoundException();
 		}
 		return videos;
 	}
+
 	public Video save(Video save){
-		return cultureMediaService.save(save);
+		return culturotecaService.save(save);
 	}
 }
 

--- a/src/test/java/culturemedia/service/impl/CulturotecaServiceImplTest.java
+++ b/src/test/java/culturemedia/service/impl/CulturotecaServiceImplTest.java
@@ -2,50 +2,64 @@ package culturemedia.service.impl;
 
 import culturemedia.exception.VideoNotFoundException;
 import culturemedia.model.Video;
+import culturemedia.repository.VideoRepository;
+import culturemedia.repository.ViewsRepository;
 import culturemedia.repository.impl.VideoRepositoryImpl;
 import culturemedia.repository.impl.ViewsRepositoryImpl;
 import culturemedia.service.CulturotecaService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 
 class CulturotecaServiceImplTest {
 
     private CulturotecaService culturotecaService;
+    @Mock
+    private VideoRepository videoRepository;
+    @Mock
+    private ViewsRepository viewsRepository;
     @BeforeEach
-    void init() {
-        culturotecaService = new CulturotecaServiceImpl(new VideoRepositoryImpl(), new ViewsRepositoryImpl());
-        List<Video> videos = List.of(
-                new Video("01", "Título 1", "Descripción 1", 4.5),
-                new Video("02", "Título 2", "Descripción 2", 5.5),
-                new Video("03", "Título 3", "Descripción 3", 4.4),
-                new Video("04", "Título 4", "Descripción 4", 3.5),
-                new Video("05", "Clic 5", "Descripción 5", 5.7),
-                new Video("06", "Clic 6", "Descripción 6", 5.1)
-        );
-
-        for (Video video : videos) {
-            culturotecaService.save(video);
-        }
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        culturotecaService = new CulturotecaServiceImpl(videoRepository,viewsRepository);
     }
 
     @Test
     void when_FindAll_does_not_find_any_video_an_VideoNotFoundException_should_be_thrown_successfully()  {
+        doReturn(List.of()).when(videoRepository).findAll();
         culturotecaService = new CulturotecaServiceImpl( new VideoRepositoryImpl(), new ViewsRepositoryImpl());
         VideoNotFoundException exception = assertThrows(VideoNotFoundException.class, () -> culturotecaService.findAll());
     }
 
     @Test
     void when_FindAll_all_videos_should_be_returned_successfully() throws VideoNotFoundException{
+        doReturn(List.of(
+                new Video("01", "Título 1", "Descripción 1", 4.5),
+                new Video("02", "Título 2", "Descripción 2", 5.5),
+                new Video("03", "Título 3", "Descripción 3", 4.4),
+                new Video("04", "Título 4", "Descripción 4", 3.5),
+                new Video("05", "Clic 5", "Descripción 5", 5.7),
+                new Video("06", "Clic 6", "Descripción 6", 5.1)
+        )).when(videoRepository).findAll();
         List<Video> videos = culturotecaService.findAll();
         assertEquals(6, videos.size());
     }
 
     @Test
     void when_FindByTitle_videos_with_the_title_should_be_returned_successfully() throws VideoNotFoundException {
+        doReturn(List.of(
+                new Video("05", "Clic 5", "Descripción 5", 5.7),
+                new Video("06", "Clic 6", "Descripción 6", 5.1)
+        )).when(videoRepository).findAll();
+
         List<Video> videos = culturotecaService.findByTitle("Clic");
         assertEquals(2, videos.size());
         assertEquals("Clic 5", videos.get(0).title());
@@ -54,21 +68,25 @@ class CulturotecaServiceImplTest {
 
     @Test
     void when_FindByTitle_does_not_find_any_video_an_VideoNotFoundException_should_be_thrown_successfully() {
+        doReturn(List.of()).when(videoRepository).find("Laboratory");
         VideoNotFoundException exception = assertThrows(VideoNotFoundException.class, () -> culturotecaService.findByTitle("Laboratory"));
         assertEquals("Video not found by title: Laboratory", exception.getMessage());
     }
 
     @Test
     void when_FindByDuration_videos_in_the_duration_range_should_be_returned_successfully() throws VideoNotFoundException {
+        doReturn(List.of(
+                new Video("01", "Título 1", "Descripción 1", 4.5),
+                new Video("02", "Título 2", "Descripción 2", 5.5),
+                new Video("06", "Clic 6", "Descripción 3", 5.1)
+        )).when(videoRepository).findAll();
         List<Video> videos = culturotecaService.findByDuration(4.5, 5.5);
         assertEquals(3, videos.size());
-        assertEquals("Título 1", videos.get(0).title());
-        assertEquals("Título 2", videos.get(1).title());
-        assertEquals("Clic 6", videos.get(2).title());
     }
 
     @Test
     void when_FindByDuration_does_not_find_any_video_an_VideoNotFoundException_should_be_thrown_successfully() {
+        doReturn(List.of()).when(videoRepository).find(1.0, 2.0);
         VideoNotFoundException exception = assertThrows(VideoNotFoundException.class, () -> culturotecaService.findByDuration(1.0, 2.0));
         assertEquals("Video not found.", exception.getMessage());
     }


### PR DESCRIPTION
Se modificaron algunos nombres en el directorio controller para seguir con la misma estructura del proyecto en cuanto a nombres. Por otra parte, se añadió o se implementó el uso de mocks para los casos de prueba del service.